### PR TITLE
Implement authenticated access for place deletion and user updates

### DIFF
--- a/part3/app/api/v1/places.py
+++ b/part3/app/api/v1/places.py
@@ -165,3 +165,27 @@ class PlaceResource(Resource):
             return {'message': 'Place not found'}, 404
 
         return {'message': 'Place updated successfully'}, 200
+
+    @jwt_required()
+    @api.response(200, 'Place deleted successfully')
+    @api.response(403, 'Unauthorized action')
+    @api.response(404, 'Place not found')
+    def delete(self, place_id):
+        """Delete a place"""
+        current = get_jwt()
+        is_admin = current.get('is_admin', False)
+        user_id = get_jwt_identity()
+
+        try:
+            place = facade.get_place(place_id)
+        except NotImplementedError:
+            return {'error': 'Place retrieval not implemented'}, 501
+
+        if not place:
+            return {'message': 'Place not found'}, 404
+
+        if not is_admin and place.owner.id != user_id:
+            return {'error': 'Unauthorized action'}, 403
+
+        facade.place_repo.delete(place_id)
+        return {'message': 'Place deleted successfully'}, 200

--- a/part3/app/api/v1/users.py
+++ b/part3/app/api/v1/users.py
@@ -1,10 +1,3 @@
-@api.route('/me')
-class UserMe(Resource):
-    @jwt_required()
-    def get(self):
-        """Return current user info from JWT token"""
-        identity = get_jwt()
-        return {'user': identity}, 200
 from flask_restx import Namespace, Resource, fields
 from flask_jwt_extended import create_access_token, get_jwt, get_jwt_identity, jwt_required
 
@@ -12,8 +5,6 @@ from app.services import facade
 
 api = Namespace('users', description='Operations on users')
 
-# Modèle de réponse — password volontairement ABSENT
-# to_dict() ne le retourne pas, et on ne le déclare pas ici non plus
 user_model = api.model('User', {
     'id':         fields.String(readonly=True, description='User unique identifier'),
     'email':      fields.String(required=True, description='User email'),
@@ -24,7 +15,6 @@ user_model = api.model('User', {
     'updated_at': fields.String(readonly=True),
 })
 
-# Modèle de création — password requis, sera hashé par bcrypt côté modèle
 create_user_model = api.model('UserCreate', {
     'email':      fields.String(required=True),
     'password':   fields.String(required=True, description='Plain-text, sera hashé avant stockage'),
@@ -32,10 +22,15 @@ create_user_model = api.model('UserCreate', {
     'last_name':  fields.String(required=True),
 })
 
-# Modèle de mise à jour — password optionnel, sera re-hashé si fourni
 update_user_model = api.model('UserUpdate', {
     'first_name': fields.String(),
     'last_name':  fields.String(),
+})
+
+admin_update_user_model = api.model('AdminUserUpdate', {
+    'first_name': fields.String(),
+    'last_name':  fields.String(),
+    'email':      fields.String(),
     'password':   fields.String(description='Nouveau mot de passe, sera hashé avant stockage'),
 })
 
@@ -66,13 +61,11 @@ class UserList(Resource):
         is_admin = current.get('is_admin', False)
 
         data = api.payload or {}
-        # First user can bootstrap the system as an admin
         if not facade.get_users():
             data['is_admin'] = True
         else:
             if not is_admin:
                 return {'error': 'Admin privileges required'}, 403
-            # Admin can explicitly set is_admin flag; default to False if not provided
             data.setdefault('is_admin', False)
 
         try:
@@ -82,7 +75,6 @@ class UserList(Resource):
             if 'in use' in msg:
                 return {'message': msg}, 409
             return {'message': msg}, 400
-        # to_dict() n'inclut pas le password — réponse sécurisée
         return user.to_dict(), 201
 
 
@@ -118,23 +110,31 @@ class UserResource(Resource):
         user = facade.get_user(user_id)
         if not user:
             api.abort(404, 'User not found')
-        # to_dict() n'inclut pas le password — jamais exposé en GET
         return user.to_dict(), 200
 
     @jwt_required()
-    @api.expect(update_user_model)
     @api.response(200, 'User updated', user_model)
-    @api.response(403, 'Admin privileges required')
+    @api.response(403, 'Unauthorized action')
     @api.response(404, 'User not found')
     def put(self, user_id):
-        """Update a user — password is re-hashed if provided"""
+        """Update a user — authenticated users can update their own first/last name; admins can update anything"""
         current = get_jwt()
-        if not current.get('is_admin'):
-            return {'error': 'Admin privileges required'}, 403
+        is_admin = current.get('is_admin', False)
+        current_user_id = get_jwt_identity()
+
+        if not is_admin and current_user_id != user_id:
+            return {'error': 'Unauthorized action'}, 403
 
         data = api.payload or {}
-        # Ensure updated email stays unique
-        if 'email' in data:
+
+        if not is_admin:
+            # Regular users cannot change email or password
+            if 'email' in data or 'password' in data:
+                return {'error': 'You cannot modify email or password'}, 400
+            allowed = {k: v for k, v in data.items() if k in ('first_name', 'last_name')}
+            data = allowed
+
+        if is_admin and 'email' in data:
             existing = facade.get_user_by_email(data['email'])
             if existing and existing.id != user_id:
                 return {'error': 'Email already in use'}, 400
@@ -142,10 +142,17 @@ class UserResource(Resource):
         try:
             user = facade.update_user(user_id, data)
         except ValueError as e:
-            msg = str(e)
-            if 'in use' in msg:
-                return {'error': msg}, 400
-            return {'error': msg}, 400
+            return {'error': str(e)}, 400
         if not user:
             api.abort(404, 'User not found')
         return user.to_dict(), 200
+
+
+@api.route('/me')
+class UserMe(Resource):
+
+    @jwt_required()
+    def get(self):
+        """Return current user info from JWT token"""
+        identity = get_jwt()
+        return {'user': identity}, 200

--- a/part3/app/services/facade.py
+++ b/part3/app/services/facade.py
@@ -155,6 +155,14 @@ class HBnBFacade:
         if not place:
             raise ValueError('place not found')
 
+        if place.owner.id == user_id:
+            raise ValueError('You cannot review your own place')
+
+        existing = [r for r in self.review_repo.get_all()
+                    if r.user.id == user_id and r.place.id == place_id]
+        if existing:
+            raise ValueError('You have already reviewed this place')
+
         from app.models.review import Review
         review = Review(
             rating=review_data['rating'],


### PR DESCRIPTION
This pull request introduces several improvements and new features to the user and place management APIs, with a focus on enhanced authorization, admin controls, and validation logic. The most important changes include stricter update permissions for users, new admin-only update models, improved place deletion authorization, and additional review validation.

**User management enhancements:**

* Regular users can now only update their own `first_name` and `last_name`, while admins are allowed to update any user field, including `email` and `password`. Unauthorized updates now return a clear error message, and email uniqueness is enforced for admin updates.
* Introduced `admin_update_user_model` for admin-level updates, separating it from the regular update model to clarify allowed fields.
* Restored the `/me` endpoint to allow authenticated users to retrieve their own information from the JWT token.

**Place management improvements:**

* Added a new `delete` method for places, enforcing that only admins or the place owner can delete a place, with appropriate error handling and response codes.

**Review validation:**

* Added checks to prevent users from reviewing their own places and from submitting multiple reviews for the same place.… updates