### PR TITLE
chore: add .gitignore file to exclude unnecessary files and directories

### DIFF
--- a/part3/.gitignore
+++ b/part3/.gitignore
@@ -1,0 +1,42 @@
+# Python bytecode
+*.pyc
+__pycache__/
+
+# Virtual environments
+HBnBvenv/
+venv/
+.env/
+.venv/
+
+# VS Code settings
+.vscode/
+
+# Test reports and logs
+*.log
+*.tmp
+*.md~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Ignore not-critical files
+curl_commands.txt
+curl_tests.sh
+
+# Ignore build artifacts
+build/
+dist/
+*.egg-info/
+
+# Ignore notebooks
+*.ipynb
+
+# Ignore backups
+*~
+
+# Ignore SQL scripts (if not critical)
+hbnb_schema.sql
+
+# Ignore other not-critical files
+# Add more patterns as needed


### PR DESCRIPTION
This pull request adds a new `.gitignore` file to the `part3` directory, specifying which files and directories should be excluded from version control. The `.gitignore` helps keep the repository clean by preventing unnecessary or sensitive files from being tracked.

File and directory exclusions:

* Added rules to ignore Python bytecode files and cache directories, such as `*.pyc` and `__pycache__/`.
* Included patterns to ignore virtual environment folders (`venv/`, `.env/`, `.venv/`, `HBnBvenv/`) and build artifacts (`build/`, `dist/`, `*.egg-info/`).
* Added exclusions for editor and OS-specific files, such as `.vscode/`, `.DS_Store`, and `Thumbs.db`.
* Specified patterns to ignore test reports, logs, backups, and notebook files (`*.log`, `*.tmp`, `*.md~`, `*~`, `*.ipynb`).
* Listed additional not-critical files, such as `curl_commands.txt`, `curl_tests.sh`, and `hbnb_schema.sql`, to be ignored.